### PR TITLE
Make hunger stats more responsive

### DIFF
--- a/html/not-alone.html
+++ b/html/not-alone.html
@@ -113,36 +113,36 @@
           </div>
         </div> <!-- END row -->
         <div class="row justify-content-between">
-          <article class="col-1 p-3">
+          <article class="col-3 col-sm-2 col-lg-1 p-3">
             <div class="p-3 text-center">
               <h1>44</h1>
             </div>
           </article>
-          <article class="col-11 p-3">
+          <article class="col-9 col-sm-10 col-lg-11 p-3">
             <div class="p-3">
               <p>percent of students <span>cut the size of their meals or skipped meals</span> because there wasn't enough money for food</p>
             </div>
           </article>
         </div> <!-- END row -->
         <div class="row justify-content-between">
-          <article class="col-1 p-3">
+          <article class="col-3 col-sm-2 col-lg-1 p-3">
             <div class="p-3 text-center">
               <h1>15</h1>
             </div>
           </article>
-          <article class="col-11 p-3">
+          <article class="col-9 col-sm-10 col-lg-11 p-3">
             <div class="p-3">
               <p>percent of students <span>lost weight</span> because there wasn't enough money for food</p>
             </div>
           </article>
         </div> <!-- END row -->
         <div class="row justify-content-between">
-          <article class="col-1 p-3">
+          <article class="col-3 col-sm-2 col-lg-1 p-3">
             <div class="p-3 text-center">
               <h1>20</h1>
             </div>
           </article>
-          <article class="col-11 p-3">
+          <article class="col-9 col-sm-10 col-lg-11 p-3">
             <div class="p-3">
               <p>percent of students <span>did not eat for a whole day</span> because there wasn't enough money for food</p>
             </div>


### PR DESCRIPTION
This branch was a misnomer; sorry about that - this PR addresses the not-alone page, not the main page.

The hunger stats are responsive on all screen sizes now.