### PR TITLE
fix 'share this site' section on help others page

### DIFF
--- a/html/help-others.html
+++ b/html/help-others.html
@@ -154,17 +154,10 @@
             </article>
           </div>
         </div> <!-- END row -->
+        <br>
+        <p class="text-center">Share this site with a friend or on social media!</p>
+        <!-- Aiko will create sharable Twitter and Facebook links once the site URL has been finalized -->
 
-        <div class="row">
-          <div class="col-lg-4 p-3">
-            <a href="#">
-              <!-- Aiko will create sharable links and add them here later -->
-              <article class="p-3 content">
-                <p>Share this site with a friend or on social media!</p>
-              </article>
-            </a>
-          </div>
-        </div> <!-- END row -->
       </div> <!-- END container -->
     </section>
 


### PR DESCRIPTION
**Do not delete the branch yet since there is a pending edit**

- isolate 'share this site' section from the rest of the green boxes since the type of message is different

Pending edit:
- add facebook and twitter share buttons once the site URL has been finalized